### PR TITLE
Add `Encoder::get_mut` method

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -145,6 +145,10 @@ impl<W: WriteBytesExt> Encoder<W> {
         self.writer
     }
 
+    pub fn writer<'x>(&'x mut self) -> &'x mut W {
+        &mut self.writer
+    }
+
     pub fn u8(&mut self, x: u8) -> EncodeResult {
         let ref mut w = self.writer;
         match x {


### PR DESCRIPTION
Method returns mutable reference to the current writer. It's useful if
you want to write some value more efficiently than it is done by
default. (In my case I need write data from VecDeque<u8> as `bytes()`
but VecDeque doesn't support slicing).

The method named just like similar method in `BufReader`
