### PR TITLE
Implement `text_borrow()` and `bytes_borrow()` methods for Decoder

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -63,6 +63,7 @@
 
 use byteorder::{self, BigEndian, ReadBytesExt};
 use std::cmp::Eq;
+use std::str::{from_utf8, Utf8Error};
 use std::error::Error;
 use std::f32;
 use std::fmt;
@@ -70,6 +71,7 @@ use std::{i8, i16, i32, i64};
 use std::io;
 use std::string;
 use skip::Skip;
+use read_slice::ReadSlice;
 use types::{Simple, Tag, Type};
 
 // Decoder Configuration ////////////////////////////////////////////////////
@@ -124,7 +126,7 @@ pub enum DecodeError {
     /// The signed integer is greater that its max value
     IntOverflow(u64),
     /// The string is not encoded in UTF-8
-    InvalidUtf8(string::FromUtf8Error),
+    InvalidUtf8(Utf8Error),
     /// Some I/O error
     IoError(io::Error),
     /// The maximum configured length is exceeded
@@ -232,6 +234,11 @@ impl From<io::Error> for DecodeError {
 
 impl From<string::FromUtf8Error> for DecodeError {
     fn from(e: string::FromUtf8Error) -> DecodeError {
+        DecodeError::InvalidUtf8(e.utf8_error())
+    }
+}
+impl From<Utf8Error> for DecodeError {
+    fn from(e: Utf8Error) -> DecodeError {
         DecodeError::InvalidUtf8(e)
     }
 }
@@ -477,6 +484,29 @@ impl<R: ReadBytesExt> Kernel<R> {
             }
         }
         Ok(v)
+    }
+
+}
+
+impl<R: ReadBytesExt+ReadSlice> Kernel<R> {
+    /// Read `begin` as the length and return that many raw bytes as slice.
+    /// If length is greater than the given `max_len`, `DecodeError::TooLong`
+    /// is returned instead.
+    pub fn raw_data_slice<'x>(&'x mut self, begin: u8, max_len: usize)
+        -> DecodeResult<&'x [u8]>
+    {
+        let len = try!(self.unsigned(begin));
+        if len > max_len as u64 {
+            return Err(DecodeError::TooLong { max: max_len, actual: len })
+        }
+        // TODO(tailhook) should it deal with eintr? Or should read_slice itself?
+        match self.reader.read_slice(len) {
+            Ok(value)  => {
+                debug_assert!(value.len() as u64 == len);
+                return Ok(value)
+            }
+            Err(e) => return Err(DecodeError::IoError(e)),
+        }
     }
 }
 
@@ -802,6 +832,40 @@ impl<R: ReadBytesExt + Skip> Decoder<R> {
     }
 }
 
+impl<R: ReadBytesExt + ReadSlice> Decoder<R> {
+    /// Decode a single UTF-8 encoded String and borrow it from underlying
+    /// buffer instead of allocating a string
+    ///
+    /// Please note that indefinite strings are not supported by this method
+    /// (Consider using `Decoder::text_iter()` for this use-case).
+    pub fn text_borrow<'x>(&'x mut self) -> DecodeResult<&'x str> {
+        match try!(self.typeinfo()) {
+            (Type::Text, 31) => unexpected_type(&(Type::Text, 31)),
+            (Type::Text,  i) => {
+                let max  = self.config.max_len_text;
+                let data = try!(self.kernel.raw_data_slice(i, max));
+                from_utf8(data).map_err(From::from)
+            }
+            ti => unexpected_type(&ti)
+        }
+    }
+
+    /// Decode a single byte string.
+    ///
+    /// Please note that indefinite byte strings are not supported by this
+    /// method (Consider using `Decoder::bytes_iter()` for this use-case).
+    pub fn bytes_borrow<'x>(&'x mut self) -> DecodeResult<&'x [u8]> {
+        match try!(self.typeinfo()) {
+            (Type::Bytes, 31) => unexpected_type(&(Type::Bytes, 31)),
+            (Type::Bytes,  i) => {
+                let max = self.config.max_len_bytes;
+                self.kernel.raw_data_slice(i, max)
+            }
+            ti => unexpected_type(&ti)
+        }
+    }
+}
+
 // Iterators ////////////////////////////////////////////////////////////////
 
 /// Iterator over the chunks of an indefinite bytes item.
@@ -945,6 +1009,12 @@ mod tests {
             r.push(t.unwrap())
         }
         assert_eq!(vec![String::from("strea"), String::from("ming")], r);
+    }
+
+    #[test]
+    fn text_borrow() {
+        let expected1 = "dfsdfsdf\r\nsdf\r\nhello\r\nsdfsfsdfs";
+        assert_eq!(Some(expected1), decoder("781f64667364667364660d0a7364660d0a68656c6c6f0d0a736466736673646673").text_borrow().ok());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod types;
 pub mod decoder;
 pub mod encoder;
 pub mod skip;
+pub mod read_slice;
 
 pub use decoder::{Config, Decoder, DecodeError, DecodeResult};
 pub use decoder::{opt, maybe, or_break};

--- a/src/read_slice.rs
+++ b/src/read_slice.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of
+// the Mozilla Public License, v. 2.0. If a copy of
+// the MPL was not distributed with this file, You
+// can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! `ReadSlice` trait to allow efficient reading of slices without copying
+use std::io::{Cursor, Seek, SeekFrom, Result};
+use std::ops::{Index, Range};
+
+/// Type which supports reading a slice from internal buffer
+///
+/// The underlying thing is only required to keep a single slice in memory, but
+/// of arbitrary length. So it theoretically be implemented for thing like
+/// BufReader with growable internal buffer.
+///
+pub trait ReadSlice {
+    /// Borrow slice from underlying buffer and advance cursor position
+    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]>;
+}
+
+impl<T> ReadSlice for Cursor<T>
+    where Cursor<T>: Seek, T: Index<Range<usize>, Output=[u8]>
+{
+    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]> {
+        let start = try!(self.seek(SeekFrom::Current(0))) as usize;
+        let end = try!(self.seek(SeekFrom::Current(n as i64))) as usize;
+        Ok(&self.get_ref()[start..end])
+    }
+}


### PR DESCRIPTION
This is a proof of concept of implementing non-allocating string reading methods. (Based on top of "num" because it were more convenient). Few details should be fleshed out.

What do you think?
