### PR TITLE
Implement `text_borrow()` and `bytes_borrow()` methods for Decoder

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -89,6 +89,7 @@
 use byteorder::{self, BigEndian, ReadBytesExt};
 use std::collections::{BTreeMap, LinkedList};
 use std::cmp::Eq;
+use std::str::{from_utf8, Utf8Error};
 use std::error::Error;
 use std::f32;
 use std::fmt::{self, Debug};
@@ -98,6 +99,7 @@ use std::string;
 use skip::Skip;
 use types::{Tag, Type};
 use value::{self, Bytes, Key, Simple, Text, Value};
+use read_slice::ReadSlice;
 
 // Decoder Configuration ////////////////////////////////////////////////////
 
@@ -165,7 +167,7 @@ pub enum DecodeError {
     /// The type of `Value` is not what is expected for a `Tag`
     InvalidTag(Value),
     /// The string is not encoded in UTF-8
-    InvalidUtf8(string::FromUtf8Error),
+    InvalidUtf8(Utf8Error),
     /// Some I/O error
     IoError(io::Error),
     /// The maximum configured length is exceeded
@@ -280,6 +282,11 @@ impl From<io::Error> for DecodeError {
 
 impl From<string::FromUtf8Error> for DecodeError {
     fn from(e: string::FromUtf8Error) -> DecodeError {
+        DecodeError::InvalidUtf8(e.utf8_error())
+    }
+}
+impl From<Utf8Error> for DecodeError {
+    fn from(e: Utf8Error) -> DecodeError {
         DecodeError::InvalidUtf8(e)
     }
 }
@@ -525,6 +532,29 @@ impl<R: ReadBytesExt> Kernel<R> {
             }
         }
         Ok(v)
+    }
+
+}
+
+impl<R: ReadBytesExt+ReadSlice> Kernel<R> {
+    /// Read `begin` as the length and return that many raw bytes as slice.
+    /// If length is greater than the given `max_len`, `DecodeError::TooLong`
+    /// is returned instead.
+    pub fn raw_data_slice<'x>(&'x mut self, begin: u8, max_len: usize)
+        -> DecodeResult<&'x [u8]>
+    {
+        let len = try!(self.unsigned(begin));
+        if len > max_len as u64 {
+            return Err(DecodeError::TooLong { max: max_len, actual: len })
+        }
+        // TODO(tailhook) should it deal with eintr? Or should read_slice itself?
+        match self.reader.read_slice(len) {
+            Ok(value)  => {
+                debug_assert!(value.len() as u64 == len);
+                return Ok(value)
+            }
+            Err(e) => return Err(DecodeError::IoError(e)),
+        }
     }
 }
 
@@ -852,6 +882,40 @@ impl<R: ReadBytesExt + Skip> Decoder<R> {
             try!(self.kernel.reader.skip(n))
         }
         Ok(())
+    }
+}
+
+impl<R: ReadBytesExt + ReadSlice> Decoder<R> {
+    /// Decode a single UTF-8 encoded String and borrow it from underlying
+    /// buffer instead of allocating a string
+    ///
+    /// Please note that indefinite strings are not supported by this method
+    /// (Consider using `Decoder::text_iter()` for this use-case).
+    pub fn text_borrow<'x>(&'x mut self) -> DecodeResult<&'x str> {
+        match try!(self.typeinfo()) {
+            (Type::Text, 31) => unexpected_type(&(Type::Text, 31)),
+            (Type::Text,  i) => {
+                let max  = self.config.max_len_text;
+                let data = try!(self.kernel.raw_data_slice(i, max));
+                from_utf8(data).map_err(From::from)
+            }
+            ti => unexpected_type(&ti)
+        }
+    }
+
+    /// Decode a single byte string.
+    ///
+    /// Please note that indefinite byte strings are not supported by this
+    /// method (Consider using `Decoder::bytes_iter()` for this use-case).
+    pub fn bytes_borrow<'x>(&'x mut self) -> DecodeResult<&'x [u8]> {
+        match try!(self.typeinfo()) {
+            (Type::Bytes, 31) => unexpected_type(&(Type::Bytes, 31)),
+            (Type::Bytes,  i) => {
+                let max = self.config.max_len_bytes;
+                self.kernel.raw_data_slice(i, max)
+            }
+            ti => unexpected_type(&ti)
+        }
     }
 }
 
@@ -1229,6 +1293,18 @@ mod tests {
             r.push(t.unwrap())
         }
         assert_eq!(vec![String::from("strea"), String::from("ming")], r);
+    }
+
+    #[test]
+    fn text_borrow() {
+        let expected1 = "dfsdfsdf\r\nsdf\r\nhello\r\nsdfsfsdfs";
+        assert_eq!(Some(expected1), decoder("781f64667364667364660d0a7364660d0a68656c6c6f0d0a736466736673646673").text_borrow().ok());
+    }
+
+    #[test]
+    fn bytes_borrow() {
+        let expected1 = &b"dfsdfsdf\r\nsdf\r\nhello\r\nsdfsfsdfs"[..];
+        assert_eq!(Some(expected1), decoder("581f64667364667364660d0a7364660d0a68656c6c6f0d0a736466736673646673").bytes_borrow().ok());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod value;
 pub mod decoder;
 pub mod encoder;
 pub mod skip;
+pub mod read_slice;
 
 #[cfg(feature="random")]
 pub mod random;

--- a/src/read_slice.rs
+++ b/src/read_slice.rs
@@ -3,8 +3,15 @@
 // the MPL was not distributed with this file, You
 // can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 //! `ReadSlice` trait to allow efficient reading of slices without copying
-use std::io::{Cursor, Result, Error, ErrorKind};
+use std::io::{self, Cursor};
+use DecodeError;
+
+pub enum Error {
+    Io(io::Error),
+    UnexpectedEOF,
+}
 
 /// Type which supports reading a slice from internal buffer
 ///
@@ -14,29 +21,38 @@ use std::io::{Cursor, Result, Error, ErrorKind};
 ///
 pub trait ReadSlice {
     /// Borrow slice from underlying buffer and advance cursor position
-    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]>;
+    fn read_slice<'x>(&'x mut self, n: usize) -> Result<&'x [u8], Error>;
+}
+
+impl From<Error> for DecodeError {
+    fn from(e: Error) -> DecodeError {
+        match e {
+            Error::Io(e) => DecodeError::IoError(e),
+            Error::UnexpectedEOF => DecodeError::UnexpectedEOF,
+        }
+    }
 }
 
 impl ReadSlice for Cursor<Vec<u8>> {
-    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]> {
-        let start = self.position();
+    fn read_slice<'x>(&'x mut self, n: usize) -> Result<&'x [u8], Error> {
+        let start = self.position() as usize;
         let end = start + n;
-        if self.get_ref().len() < end as usize {
-            return Err(Error::new(ErrorKind::InvalidInput, "eof reached"));
+        if self.get_ref().len() < end {
+            return Err(Error::UnexpectedEOF);
         }
-        self.set_position(end);
-        Ok(&self.get_ref()[start as usize..end as usize])
+        self.set_position(end as u64);
+        Ok(&self.get_ref()[start..end])
     }
 }
 
 impl<'a> ReadSlice for Cursor<&'a [u8]> {
-    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]> {
-        let start = self.position();
+    fn read_slice<'x>(&'x mut self, n: usize) -> Result<&'x [u8], Error> {
+        let start = self.position() as usize;
         let end = start + n;
-        if self.get_ref().len() < end as usize {
-            return Err(Error::new(ErrorKind::InvalidInput, "eof reached"));
+        if self.get_ref().len() < end {
+            return Err(Error::UnexpectedEOF);
         }
-        self.set_position(end);
-        Ok(&self.get_ref()[start as usize..end as usize])
+        self.set_position(end as u64);
+        Ok(&self.get_ref()[start..end])
     }
 }

--- a/src/read_slice.rs
+++ b/src/read_slice.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of
+// the Mozilla Public License, v. 2.0. If a copy of
+// the MPL was not distributed with this file, You
+// can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! `ReadSlice` trait to allow efficient reading of slices without copying
+use std::io::{Cursor, Result, Error, ErrorKind};
+
+/// Type which supports reading a slice from internal buffer
+///
+/// The underlying thing is only required to keep a single slice in memory, but
+/// of arbitrary length. So it theoretically be implemented for thing like
+/// BufReader with growable internal buffer.
+///
+pub trait ReadSlice {
+    /// Borrow slice from underlying buffer and advance cursor position
+    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]>;
+}
+
+impl ReadSlice for Cursor<Vec<u8>> {
+    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]> {
+        let start = self.position();
+        let end = start + n;
+        if self.get_ref().len() < end as usize {
+            return Err(Error::new(ErrorKind::InvalidInput, "eof reached"));
+        }
+        self.set_position(end);
+        Ok(&self.get_ref()[start as usize..end as usize])
+    }
+}
+
+impl<'a> ReadSlice for Cursor<&'a [u8]> {
+    fn read_slice<'x>(&'x mut self, n: u64) -> Result<&'x [u8]> {
+        let start = self.position();
+        let end = start + n;
+        if self.get_ref().len() < end as usize {
+            return Err(Error::new(ErrorKind::InvalidInput, "eof reached"));
+        }
+        self.set_position(end);
+        Ok(&self.get_ref()[start as usize..end as usize])
+    }
+}


### PR DESCRIPTION
A follow up of #8. I couldn't get generic cursor working, so only `Cursor<Vec<u8>>` and `Cursor<&[u8]>` works, which probably covers majority of cases.

Also note that `InvalidUtf8` slightly changed signature. That's because `String::from_utf8` returns the input vector in the error message. I don't think it's needed. So I've normalized error to simpler one returned from `str::from_utf8`. But it may break some code.

Also I'm not sure which error should be returned from `read_slice`. For Cursor it could be `Result<&[u8], ()>` but for imaginary other implementation it needs to be `io::Error`, so which code return for EOF case is not clear.
