### PR TITLE
Upgrade to byteorder >= 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "cbor"
 random = ["quickcheck"]
 
 [dependencies]
-byteorder = "> 0.3.0"
-libc      = "> 0.1.0"
+byteorder = ">= 0.5.0"
+libc      = ">  0.1.0"
 
 [dependencies.quickcheck]
 version  = ">= 0.2.21"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -86,7 +86,7 @@
 //! assert_eq!(None, opt(d.u8()).unwrap())
 //! ```
 
-use byteorder::{self, BigEndian, ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt};
 use slice::{ReadSlice, ReadSliceError};
 use std::collections::{BTreeMap, LinkedList};
 use std::cmp::Eq;
@@ -261,15 +261,6 @@ impl Error for DecodeError {
             DecodeError::IoError(ref e)     => Some(e),
             DecodeError::InvalidUtf8(ref e) => Some(e),
             _                               => None
-        }
-    }
-}
-
-impl From<byteorder::Error> for DecodeError {
-    fn from(e: byteorder::Error) -> DecodeError {
-        match e {
-            byteorder::Error::UnexpectedEOF => DecodeError::UnexpectedEOF,
-            byteorder::Error::Io(e)         => DecodeError::IoError(e)
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -66,7 +66,7 @@
 //! }
 //! ```
 
-use byteorder::{self, BigEndian, WriteBytesExt};
+use byteorder::{BigEndian, WriteBytesExt};
 use std::io;
 use std::error::Error;
 use std::fmt;
@@ -110,15 +110,6 @@ impl Error for EncodeError {
         match *self {
             EncodeError::IoError(ref e) => Some(e),
             _                           => None
-        }
-    }
-}
-
-impl From<byteorder::Error> for EncodeError {
-    fn from(e: byteorder::Error) -> EncodeError {
-        match e {
-            byteorder::Error::UnexpectedEOF => EncodeError::UnexpectedEOF,
-            byteorder::Error::Io(e)         => EncodeError::IoError(e)
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,8 @@
 
 //! CBOR types and tags definitions.
 
-use byteorder::{Error, ReadBytesExt};
+use byteorder::{ReadBytesExt};
+use std::io::Error;
 
 /// The CBOR types.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]


### PR DESCRIPTION
This change is not backward compatible due to byteorder having removed its custom error type.

See: https://github.com/BurntSushi/byteorder/pull/40
